### PR TITLE
Clean Whitelist result from well-formed html tags

### DIFF
--- a/wagtail/wagtailcore/whitelist.py
+++ b/wagtail/wagtailcore/whitelist.py
@@ -97,7 +97,10 @@ class Whitelister(object):
         attributes"""
         doc = BeautifulSoup(html, 'html5lib')
         cls.clean_node(doc, doc)
-        return doc.decode()
+        if hasattr(doc, 'body'):
+            return "".join([child.decode() for child in doc.body.childGenerator()])
+        else:
+            return doc.decode()
 
     @classmethod
     def clean_node(cls, doc, node):


### PR DESCRIPTION
BeautifulSoup with html5lib parser adds html, head and body tags to produce well-formed html. This tags are not allowed within body of html page and should be stripped
